### PR TITLE
Add Sep2024TBv2 module locator

### DIFF
--- a/ModuleMaps/modulelocator_Sep2024TBv2.txt
+++ b/ModuleMaps/modulelocator_Sep2024TBv2.txt
@@ -1,0 +1,9 @@
+plane u v irot typecode econdidx captureblock captureblockidx slinkidx fedid zside
+1 5 1 3 ML-F3WX-IH0019 0 0 0 0 0 -1
+1 5 2 1 ML-F3WX-IH0020 1 0 0 0 0 -1
+1 5 3 3 ML-F3WX-IH0018 2 0 0 0 0 -1
+2 5 4 3 ML-F3WX-IH0016 0 1 1 0 0 -1
+2 5 5 1 ML-F3WX-IH0017 1 1 1 0 0 -1
+2 5 6 3 ML-F3WX-IH0014 2 1 1 0 0 -1
+3 5 5 1 ML-R3WX-42QH00006 0 2 2 0 0 -1
+3 5 6 0 ML-F3WX-IH0015 1 2 2 0 0 -1


### PR DESCRIPTION
This PR adds the Sep2024TBv2 module locator needed to create a relval using 2024 test beam data

@smuzaffar : I will also need to add calibration files in the data directory of RecoLocalCalo/HGCalRecProducers , how do I create a new CMSSW data repository?

@pfs 
